### PR TITLE
Update bootstrap-tokenfield.js location comment and copyright date

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -1,7 +1,7 @@
 /*!
  * bootstrap-tokenfield
- * https://github.com/sliptree/bootstrap-tokenfield
- * Copyright 2013-2014 Sliptree and other contributors; Licensed MIT
+ * https://github.com/Open-Xchange-Frontend/bootstrap-tokenfield
+ * Copyright 2013-2016 Sliptree and other contributors; Licensed MIT
  */
 
 (function (factory) {


### PR DESCRIPTION
Updated comment at top of file to properly indicate the URL/source of this fork. Also update copyright date to 2016